### PR TITLE
Remove socket redundant configuration

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingUtil.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingUtil.java
@@ -186,7 +186,6 @@ public class RemotingUtil {
         SocketChannel sc = null;
         try {
             sc = SocketChannel.open();
-            sc.configureBlocking(true);
             sc.socket().setSoLinger(false, -1);
             sc.socket().setTcpNoDelay(true);
             sc.socket().setReceiveBufferSize(1024 * 64);


### PR DESCRIPTION
SocketChannel 默认 blocking = true , 没必要先设置 blocking = true，后面再次设置 blocking = false